### PR TITLE
Decode byte-like strings to utf-8

### DIFF
--- a/pysofa/sofa.py
+++ b/pysofa/sofa.py
@@ -247,6 +247,15 @@ class SOFA(object):
         self.Receiver = AudioObject('Receiver', tblsfile)
         self.Emitter = AudioObject('Emitter', tblsfile)
 
+        # If the DataType isn't stored as a String, convert
+        # it to a string.
+        if type(self.DataType) != str:
+            try:
+                convertedDataType = str(self.DataType, 'utf-8')
+                self.DataType = convertedDataType
+            except TypeError:
+                raise Exception('DataType cannot be converted to a string')
+
         # Read the Data included in the SOFA file
         if self.DataType == 'FIR':
             self.FIR = FIR(tblsfile)


### PR DESCRIPTION
Hi!

I was unable to open RICE data using the current code, because they stored DataType as using numpy-bytes instead of a string. I added a few lines that converts DataType to string, if possible.